### PR TITLE
Support compilation on Java 11

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/remote_terminal_access/ssh/DiagnoseCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/remote_terminal_access/ssh/DiagnoseCommand.java
@@ -80,7 +80,7 @@ public class DiagnoseCommand extends AbstractRemoteSshCommand {
             try {// number?
                 int n = Integer.parseInt(buildName);
                 build = p.getBuildByNumber(n);
-            } catch (NumberFormatException _) {
+            } catch (NumberFormatException e) {
                 // permalink?
                 Permalink link = p.getPermalinks().get(buildName);
                 if (link!=null)


### PR DESCRIPTION
`src/main/java/org/jenkinsci/plugins/remote_terminal_access/ssh/DiagnoseCommand.java`:83: error: as of release 9, '_' is a keyword, and may not be used as an identifier